### PR TITLE
feat: call read layout inference module

### DIFF
--- a/htsinfer/htsinfer.py
+++ b/htsinfer/htsinfer.py
@@ -4,10 +4,11 @@
 import argparse
 import logging
 import sys
-from typing import (Optional, Sequence)
+from typing import (Any, Dict, Optional, Sequence)
 
 from htsinfer import (
     infer_single_paired,
+    infer_read_layout,
     __version__,
 )
 
@@ -92,18 +93,34 @@ def main() -> None:
     Args:
         args: Command-line arguments and their values.
     """
+
+    # Parse CLI arguments
     args = parse_args()
+
+    # Set up logging
     setup_logging(
         verbose=args.verbose,
         debug=args.debug,
     )
+
+    # Initialize results container
     LOGGER.info("Started script...")
     LOGGER.debug(f"CLI options: {args}")
-    results = {}
+    results: Dict[str, Any] = {}
+
+    # Infer library type
     results['single_paired'] = infer_single_paired.infer(
         file_1=args.file_1,
         file_2=args.file_2,
     )
+
+    # Infer read layout
+    results['read_layout'] = infer_read_layout.infer(
+        file_1=args.file_1,
+        file_2=args.file_2,
+    )
+
+    # Log results & end script
     LOGGER.info(f"Results: {results}")
     LOGGER.info("Done.")
 

--- a/htsinfer/infer_read_layout.py
+++ b/htsinfer/infer_read_layout.py
@@ -1,8 +1,20 @@
 """Infer read layout from sample data."""
 
 
-def infer():
-    """Main function coordinating the execution of all other functions.
-    Should be imported/called from main app and return results to it.
+def infer(
+    file_1: str,  # pylint: disable=unused-argument
+    file_2: str = None,  # pylint: disable=unused-argument
+) -> str:
+    """Infers read layout for single- or paired-ended sequencing libraries in
+    FASTQ format.
+
+    Args:
+        file_1 (str) : File path to read/first mate library.
+        file_2 (str) : File path to second mate library.
+
+    Returns:
+        LIBTYPE string according to Salmon documentation, cf.
+        https://salmon.readthedocs.io/en/latest/library_type.html
     """
-    # implement me
+    # implement logic
+    return "U"


### PR DESCRIPTION
* call read layout inference functionality from main app
* add function signature, docstring and dummy return value to `htsinfer.infer_read_layout.infer()`

Fixes #23 

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
      to not work as expected)
- [ ] Documentation update

### Checklist

Please carefully read these items and tick them off if the statements are true
_or do not apply_.

- [x] I have performed a self-review of my own code
- [x] My code follows the existing coding style, lints and generates no new
      warnings
- [x] I have added type annotations to all function/method signatures, and I
      have added type annotations for any local variables that are non-trivial,
      potentially ambiguous or might otherwise benefit from explicit typing.
- [x] I have commented my code in hard-to-understand areas
- [x] I have added ["Google-style docstrings"] to all new modules, classes,
      methods/functions or updated previously existing ones
- [x] I have added tests that prove my fix is effective or that my feature
      works
- [x] New and existing unit tests pass locally with my changes and I have not
      reduced the code coverage relative to the previous state
- [x] I have updated any sections of the app's documentation that are affected
      by the proposed changes

If for some reason you are unable to tick off all boxes, please leave a
comment explaining the issue you are facing so that we can work on it
together.
