### PR TITLE
feat: add CLI arg to pass organism

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ HTSinfer infers metadata from High Throughput Sequencing (HTS) data.
 ## Usage
 
 ```sh
-htsinfer [-h] -f1 FILE [-f2 FILE] [-n INT] [--verbose] [--debug] [--version]
+htsinfer [-h] -f1 FILE [-f2 FILE] [-n INT] [-o STR] [--verbose] [--debug] [--version]
 ```
 
 ## Parameters

--- a/htsinfer/htsinfer.py
+++ b/htsinfer/htsinfer.py
@@ -53,8 +53,9 @@ def parse_args(
         type=str,
         default='hsapiens',
         help=(
-            "source organism of the sequencing library; if provided, will not "
-            "not be inferred by the application"
+            "source organism of the sequencing library, either as a short "
+            "name (e.g., 'hsapiens') or taxon identifier (e.g., '9606'); if "
+            "provided, will not not be inferred by the application"
         )
     )
     parser.add_argument(

--- a/htsinfer/htsinfer.py
+++ b/htsinfer/htsinfer.py
@@ -48,6 +48,16 @@ def parse_args(
         )
     )
     parser.add_argument(
+        '-o', '--organism',
+        metavar="STR",
+        type=str,
+        default='hsapiens',
+        help=(
+            "source organism of the sequencing library; if provided, will not "
+            "not be inferred by the application"
+        )
+    )
+    parser.add_argument(
         '--verbose', "-v",
         action='store_true',
         default=False,
@@ -118,6 +128,7 @@ def main() -> None:
     results['read_layout'] = infer_read_layout.infer(
         file_1=args.file_1,
         file_2=args.file_2,
+        organism=args.organism,
     )
 
     # Log results & end script

--- a/htsinfer/infer_read_layout.py
+++ b/htsinfer/infer_read_layout.py
@@ -1,9 +1,12 @@
 """Infer read layout from sample data."""
 
+from typing import Union
+
 
 def infer(
     file_1: str,  # pylint: disable=unused-argument
     file_2: str = None,  # pylint: disable=unused-argument
+    organism: Union[int, str] = "hsapiens",  # pylint: disable=unused-argument
 ) -> str:
     """Infers read layout for single- or paired-ended sequencing libraries in
     FASTQ format.

--- a/htsinfer/infer_read_layout.py
+++ b/htsinfer/infer_read_layout.py
@@ -12,8 +12,11 @@ def infer(
     FASTQ format.
 
     Args:
-        file_1 (str) : File path to read/first mate library.
-        file_2 (str) : File path to second mate library.
+        file_1: File path to read/first mate library.
+        file_2: File path to second mate library.
+        organism: Source organism of the sequencing library; either a short
+            name (string, e.g., `hsapiens`) or a taxon identifier (integer,
+            e.g., `9606`).
 
     Returns:
         LIBTYPE string according to Salmon documentation, cf.


### PR DESCRIPTION
* add optional CLI argument (default: `hsapiens`) to pass organism to application as either a short name or taxon identifier
* add corresponding argument to `htsinfer.infer_read_layout.infer()` signature and docstring

Fixes #24 

### Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
      to not work as expected)
- [ ] Documentation update

### Checklist

Please carefully read these items and tick them off if the statements are true
_or do not apply_.

- [x] I have performed a self-review of my own code
- [x] My code follows the existing coding style, lints and generates no new
      warnings
- [x] I have added type annotations to all function/method signatures, and I
      have added type annotations for any local variables that are non-trivial,
      potentially ambiguous or might otherwise benefit from explicit typing.
- [x] I have commented my code in hard-to-understand areas
- [x] I have added ["Google-style docstrings"] to all new modules, classes,
      methods/functions or updated previously existing ones
- [x] I have added tests that prove my fix is effective or that my feature
      works
- [x] New and existing unit tests pass locally with my changes and I have not
      reduced the code coverage relative to the previous state
- [x] I have updated any sections of the app's documentation that are affected
      by the proposed changes

If for some reason you are unable to tick off all boxes, please leave a
comment explaining the issue you are facing so that we can work on it
together.
