### PR TITLE
feat: improve handling of positional args & usage

### DIFF
--- a/htsinfer/__init__.py
+++ b/htsinfer/__init__.py
@@ -2,4 +2,4 @@
 
 from htsinfer.htsinfer import HtsInfer  # noqa:F401
 
-__version__ = "0.5.2"
+__version__ = "0.6.0"

--- a/htsinfer/cli.py
+++ b/htsinfer/cli.py
@@ -37,7 +37,7 @@ def parse_args() -> argparse.Namespace:
     )
 
     # custom actions
-    class __PathsAction(argparse.Action):
+    class PathsAction(argparse.Action):
         def __call__(self, parser, namespace, values, option_string=None):
             if len(values) > 2:
                 parser.print_usage(file=sys.stderr)
@@ -63,7 +63,7 @@ def parse_args() -> argparse.Namespace:
         'paths',
         nargs="+",
         type=Path,
-        action=__PathsAction,
+        action=PathsAction,
         metavar="PATH",
         help=(
             "either one or two paths to FASTQ files representing the "

--- a/htsinfer/cli.py
+++ b/htsinfer/cli.py
@@ -38,7 +38,14 @@ def parse_args() -> argparse.Namespace:
 
     # custom actions
     class PathsAction(argparse.Action):
-        def __call__(self, parser, namespace, values, option_string=None):
+        """Sanitize ``paths`` parsing in positional args."""
+        def __call__(
+            self,
+            parser,
+            namespace,
+            values,
+            option_string=None,
+        ) -> None:
             if len(values) > 2:
                 parser.print_usage(file=sys.stderr)
                 sys.stderr.write(

--- a/htsinfer/cli.py
+++ b/htsinfer/cli.py
@@ -27,14 +27,6 @@ def parse_args() -> argparse.Namespace:
         Parsed CLI arguments.
     """
     # set metadata
-    usage = (
-        """htsinfer [--output-directory PATH] [--temporary-directory PATH]
-                [--cleanup-regime {DEFAULT,KEEP_ALL,KEEP_NONE,KEEP_RESULTS}]
-                [--records INT ] [--verbosity {DEBUG,INFO,WARN,ERROR,CRITICAL}]
-                [-h] [--version]
-                FASTQ_PATH [FASTQ_PATH]
-        """
-    )
     description = (
         f"{sys.modules[__name__].__doc__}\n\n"
         ""
@@ -44,11 +36,24 @@ def parse_args() -> argparse.Namespace:
         "(zavolab-biozentrum@unibas.ch)"
     )
 
+    # custom actions
+    class __PathsAction(argparse.Action):
+        def __call__(self, parser, namespace, values, option_string=None):
+            if len(values) > 2:
+                parser.print_usage(file=sys.stderr)
+                sys.stderr.write(
+                    "htsinfer: error: only one or two of the following "
+                    "arguments are allowed: PATH\n"
+                )
+                parser.exit(2)
+            if len(values) == 1:
+                values.append(None)
+            setattr(namespace, self.dest, values)
+
     # instantiate parser
     parser = argparse.ArgumentParser(
         description=description,
         epilog=epilog,
-        usage=usage,
         add_help=False,
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
@@ -58,10 +63,11 @@ def parse_args() -> argparse.Namespace:
         'paths',
         nargs="+",
         type=Path,
-        metavar="FASTQ_PATH",
+        action=__PathsAction,
+        metavar="PATH",
         help=(
-            "either one or two file paths to the read library to be "
-            "evaluated."
+            "either one or two paths to FASTQ files representing the "
+            "sequencing library to be evaluated."
         ),
     )
     parser.add_argument(
@@ -120,24 +126,12 @@ def parse_args() -> argparse.Namespace:
         help="show version information and exit",
     )
 
+    # fix faulty usage string for nargs={1,2}
+    parser.usage = parser.format_usage()
+    parser.usage = parser.usage.replace("PATH [PATH ...]", "PATH [PATH]")
+
     # return parsed arguments
     return parser.parse_args()
-
-
-def validate_args(args: argparse.Namespace) -> None:
-    """Validate CLI arguments.
-
-    Args:
-        args: CLI arguments.
-
-    Raises:
-        ValueError: A CLI argument is invalid.
-    """
-    # ensure that not more than two file paths are passed
-    if len(args.paths) > 2:
-        raise ValueError("A maximum of two file paths can be specified.")
-    if len(args.paths) == 1:
-        args.paths.append(None)
 
 
 def setup_logging(verbosity: str = 'INFO') -> None:
@@ -159,7 +153,6 @@ def main() -> None:
     try:
         # handle CLI args
         args = parse_args()
-        validate_args(args=args)
 
         # set up logging
         setup_logging(verbosity=args.verbosity)


### PR DESCRIPTION
### Description

* Specifying more than two input files / positional arguments exits the `htsinfer` CLI executable in the same way that other argument issues do, with printing the usage string, followed by an error message of the same format (`htsinfer: error: {error_message}`)
* Faulty auto-generated usage string, resulting from `argparse` not supporting a specified range of `nargs`, patched by replacing the faulty/misleading part (`PATH [PATH ...]` to `PATH [PATH]`); this dispenses with having to specify the usage string manually

Fixes #68