### PR TITLE
Bug fixes

### DIFF
--- a/htsinfer/get_library_source.py
+++ b/htsinfer/get_library_source.py
@@ -96,7 +96,7 @@ class GetLibSource:
         )
         if self.paths[1] is not None:
             source.file_2 = self.get_source(
-                fastq=self.paths[0],
+                fastq=self.paths[1],
                 index=index,
             )
         return source

--- a/htsinfer/get_library_stats.py
+++ b/htsinfer/get_library_stats.py
@@ -57,7 +57,7 @@ class GetLibStats:
         LOGGER.info(f"Obtaining statistics for file: {self.paths[0]}")
         if self.paths[1] is not None:
             stats.file_2.read_length.min, stats.file_2.read_length.max = (
-                self.fastq_get_min_max_read_length(fastq=self.paths[0])
+                self.fastq_get_min_max_read_length(fastq=self.paths[1])
             )
 
         return stats

--- a/htsinfer/get_read_orientation.py
+++ b/htsinfer/get_read_orientation.py
@@ -585,6 +585,7 @@ class GetOrientation:
         if reads >= self.min_mapped_reads:
             if fraction_most_common_state > self.min_fraction:
                 orientation.relationship = most_common_state
+                assert orientation.relationship is not None
                 if orientation.relationship.value[-2:] == "SF":
                     orientation.file_1 = StatesOrientation("SF")
                     orientation.file_2 = StatesOrientation("SR")

--- a/htsinfer/models.py
+++ b/htsinfer/models.py
@@ -182,9 +182,9 @@ class ResultsType(BaseModel):
         file_2: Library type of the second file.
         relationship: Type/mate relationship between the provided files.
     """
-    file_1: StatesType = StatesType.not_available
-    file_2: StatesType = StatesType.not_available
-    relationship: StatesTypeRelationship = (
+    file_1: Optional[StatesType] = StatesType.not_available
+    file_2: Optional[StatesType] = StatesType.not_available
+    relationship: Optional[StatesTypeRelationship] = (
         StatesTypeRelationship.not_available
     )
 
@@ -270,9 +270,9 @@ class ResultsOrientation(BaseModel):
         file_1: Read orientation of first file.
         file_2: Read orientation of second file.
     """
-    file_1: StatesOrientation = StatesOrientation.not_available
-    file_2: StatesOrientation = StatesOrientation.not_available
-    relationship: StatesOrientationRelationship = (
+    file_1: Optional[StatesOrientation] = StatesOrientation.not_available
+    file_2: Optional[StatesOrientation] = StatesOrientation.not_available
+    relationship: Optional[StatesOrientationRelationship] = (
         StatesOrientationRelationship.not_available
     )
 


### PR DESCRIPTION
### Description

- fix `pydantic`'s validation of classes depending on enumerators with `None` values by explicitly allowing `None` instead of the enumerator class (workaround for reported bug in Pydantic: https://github.com/samuelcolvin/pydantic/issues/3049)
- fix double assignment of same file to both first and second mate in modules `htsinfer.get_library_source` and `htsinfer.get_library_stats`