### PR TITLE
feat: infer presence of polyA tail fragments

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -2,6 +2,11 @@
 # Read the Docs configuration file
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 version: 2
+
+build:
+  os: "ubuntu-20.04"
+  tools:
+    python: "mambaforge-4.10"
 sphinx:
    configuration: docs/api/conf.py
 formats:

--- a/README.md
+++ b/README.md
@@ -64,9 +64,11 @@ example library:
    "read_layout": {
       "file_1": {
          "adapt_3": "AATGATACGGCGACC"
+         "polyA_frac": 10.0
       },
       "file_2": {
          "adapt_3": "AATGATACGGCGACC"
+         "polyA_frac": 10.0
       }
    },
    "read_orientation": {

--- a/environment.yml
+++ b/environment.yml
@@ -13,5 +13,6 @@ dependencies:
   - pysam>=0.16.0
   - python>=3.6, <=3.10
   - star>=2.7.6
+  - cutadapt>=3.5
   - pip:
     - -e .

--- a/htsinfer/exceptions.py
+++ b/htsinfer/exceptions.py
@@ -40,3 +40,7 @@ class WorkEnvProblem(Exception):
 
 class TranscriptsFastaProblem(Exception):
     """Exception raised when an invalid transcripts fasta file is passed."""
+
+
+class CutadaptProblem(Exception):
+    """Exception raised when running cutadapt commands."""

--- a/htsinfer/get_read_layout.py
+++ b/htsinfer/get_read_layout.py
@@ -111,7 +111,8 @@ class GetReadLayout:
 
     def get_poly_a(self, file=Path()) -> float:
         """Run cutadapt and parse report"""
-        
+
+        # process file 1
         LOGGER.debug("Parsing with Cutadapt...")
         cmd: List[str] = [
                 "cutadapt", "-a", "A{100}",
@@ -124,7 +125,6 @@ class GetReadLayout:
                 text=True,
                 check=True,
             )
-            # Regex for parsing the cutadapt report
             match = re.findall("Reads with adapters:.*", result.stdout)
             fraction = re.findall(r"\(.*\)", match[0])
             result_fraction = float(fraction[0].strip("()%"))

--- a/htsinfer/get_read_layout.py
+++ b/htsinfer/get_read_layout.py
@@ -111,8 +111,7 @@ class GetReadLayout:
 
     def get_poly_a(self, file=Path()) -> float:
         """Run cutadapt and parse report"""
-
-        # process file 1
+        
         LOGGER.debug("Parsing with Cutadapt...")
         cmd: List[str] = [
                 "cutadapt", "-a", "A{100}",
@@ -125,6 +124,7 @@ class GetReadLayout:
                 text=True,
                 check=True,
             )
+            # Regex for parsing the cutadapt report
             match = re.findall("Reads with adapters:.*", result.stdout)
             fraction = re.findall(r"\(.*\)", match[0])
             result_fraction = float(fraction[0].strip("()%"))

--- a/htsinfer/get_read_layout.py
+++ b/htsinfer/get_read_layout.py
@@ -1,13 +1,15 @@
 """Infer adapter sequences present in reads."""
 
+import re
 import logging
 from pathlib import Path
+import subprocess as sp
 from typing import (Dict, List, Optional, Tuple)
 
 import ahocorasick as ahc  # type: ignore
 from Bio.SeqIO.QualityIO import FastqGeneralIterator  # type: ignore
 
-from htsinfer.exceptions import FileProblem
+from htsinfer.exceptions import FileProblem, CutadaptProblem
 from htsinfer.models import ResultsLayout, Config
 from htsinfer.utils import (
     convert_dict_to_df,
@@ -69,6 +71,7 @@ class GetReadLayout:
         self.path_2: Optional[Path] = config.args.path_2_processed
         self.adapter_file: Path = config.args.read_layout_adapter_file
         self.out_dir: Path = config.args.out_dir
+        self.tmp_dir: Path = config.args.tmp_dir
         self.min_match_pct: float = config.args.read_layout_min_match_pct
         self.min_freq_ratio: float = config.args.read_layout_min_freq_ratio
         self.results: ResultsLayout = ResultsLayout()
@@ -78,6 +81,7 @@ class GetReadLayout:
 
         # process file 1
         LOGGER.debug(f"Processing file: '{self.path_1}'")
+        self.results.file_1.polyA_frac = self.get_poly_a(self.path_1)
         file_1_adapt_3 = GetAdapter3(
             path=self.path_1,
             adapter_file=self.adapter_file,
@@ -92,6 +96,8 @@ class GetReadLayout:
         # process file 2
         if self.path_2 is not None:
             LOGGER.debug(f"Processing file: '{self.path_2}'")
+            self.results.file_2.polyA_frac = self.get_poly_a(self.path_2)
+
             file_2_adapt_3 = GetAdapter3(
                 path=self.path_2,
                 adapter_file=self.adapter_file,
@@ -102,6 +108,33 @@ class GetReadLayout:
             file_2_adapt_3.evaluate()
             self.results.file_2.adapt_3 = file_2_adapt_3.result
             LOGGER.debug(f"3' adapter sequence: {self.results.file_2}")
+
+    def get_poly_a(self, file=Path()) -> float:
+        """Run cutadapt and parse report"""
+
+        # process file 1
+        LOGGER.debug("Parsing with Cutadapt...")
+        cmd: List[str] = [
+                "cutadapt", "-a", "A{100}",
+                "-o", str(self.tmp_dir) + "/" + "out.fastq", file,
+            ]
+        try:
+            result = sp.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            match = re.findall("Reads with adapters:.*", result.stdout)
+            fraction = re.findall(r"\(.*\)", match[0])
+            result_fraction = float(fraction[0].strip("()%"))
+        except sp.CalledProcessError as exc:
+            raise CutadaptProblem(
+                f"Failed to run cutadapt for command: {cmd}"
+            ) from exc
+        LOGGER.debug("Successfully parsed the cutadapt report")
+
+        return result_fraction
 
 
 class GetAdapter3():

--- a/htsinfer/models.py
+++ b/htsinfer/models.py
@@ -284,11 +284,14 @@ class Layout(BaseModel):
 
     Args:
         adapt_3: Adapter sequence ligated to 3'-end of sequence.
+        polyA_frac: Fraction of reads containing polyA tails.
 
     Attributes:
         adapt_3: Adapter sequence ligated to 3'-end of sequence.
+        polyA_frac: Fraction of reads containing polyA tails.
     """
     adapt_3: Optional[str] = None
+    polyA_frac: Optional[float] = None
 
 
 class ResultsLayout(BaseModel):

--- a/tests/test_get_read_layout.py
+++ b/tests/test_get_read_layout.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from htsinfer.exceptions import FileProblem
+from htsinfer.exceptions import FileProblem, CutadaptProblem
 from htsinfer.get_read_layout import (
     GetReadLayout,
     GetAdapter3,
@@ -63,8 +63,10 @@ class TestGetReadLayout:
         test_instance = GetReadLayout(config=CONFIG)
         test_instance.evaluate()
         assert test_instance.results == ResultsLayout(
-            file_1=Layout(adapt_3="AAAAAAAAAAAAAAA"),
-            file_2=Layout(adapt_3=None),
+            file_1=Layout(adapt_3="AAAAAAAAAAAAAAA",
+                          polyA_frac=2.6),
+            file_2=Layout(adapt_3=None,
+                          polyA_frac=None),
         )
 
     def test_evaluate_two_files(self, tmpdir):
@@ -73,14 +75,27 @@ class TestGetReadLayout:
         CONFIG.args.path_2_processed = FILE_SRA_SAMPLE_2
         CONFIG.args.read_layout_adapter_file = FILE_ADAPTER
         CONFIG.args.out_dir = tmpdir
+        CONFIG.args.tmp_dir = tmpdir
         CONFIG.args.lib_source_min_match_pct = 2
         CONFIG.args.read_layout_min_freq_ratio = 1
         test_instance = GetReadLayout(config=CONFIG)
         test_instance.evaluate()
         assert test_instance.results == ResultsLayout(
-            file_1=Layout(adapt_3="AAAAAAAAAAAAAAA"),
-            file_2=Layout(adapt_3="AAAAAAAAAAAAAAA"),
+            file_1=Layout(adapt_3="AAAAAAAAAAAAAAA",
+                          polyA_frac=2.6),
+            file_2=Layout(adapt_3="AAAAAAAAAAAAAAA",
+                          polyA_frac=2.6),
         )
+
+    def test_raise_cutadapt_problem(self, tmpdir):
+        """Get read layout for a single file."""
+        CONFIG.args.tmp_dir = tmpdir
+        CONFIG.args.path_1_processed = FILE_SRA_SAMPLE_2
+        CONFIG.args.path_2_processed = None
+        test_instance = GetReadLayout(config=CONFIG)
+        test_instance.path_1 = "."
+        with pytest.raises(CutadaptProblem):
+            test_instance.get_poly_a()
 
 
 class TestGetAdapter3:

--- a/tests/test_htsinfer.py
+++ b/tests/test_htsinfer.py
@@ -411,10 +411,12 @@ class TestHtsInfer:
    },
    "read_layout": {
       "file_1": {
-         "adapt_3": null
+         "adapt_3": null,
+         "polyA_frac": null
       },
       "file_2": {
-         "adapt_3": null
+         "adapt_3": null,
+         "polyA_frac": null
       }
    },
    "read_orientation": {


### PR DESCRIPTION
### Description

Added the cutadapt step in get_read_layout function. The report is parsed and the fraction of reads containing polyA tails is reported.

Also changed the __.readthedocs.yaml__ to use mamba instead of conda.

Fixes #86

### Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
      to not work as expected)
- [ ] Documentation update

### Checklist

Please carefully read these items and tick them off if the statements are true
_or do not apply_.

- [x] I have performed a self-review of my own code
- [x] My code follows the existing coding style, lints and generates no new
      warnings
- [x] I have added type annotations to all function/method signatures, and I
      have added type annotations for any local variables that are non-trivial,
      potentially ambiguous or might otherwise benefit from explicit typing.
- [x] I have commented my code in hard-to-understand areas
- [x] I have added ["Google-style docstrings"] to all new modules, classes,
      methods/functions or updated previously existing ones
- [x] I have added tests that prove my fix is effective or that my feature
      works
- [x] New and existing unit tests pass locally with my changes and I have not
      reduced the code coverage relative to the previous state
- [x] I have updated any sections of the app's documentation that are affected
      by the proposed changes