### PR TITLE
refactor: wrap long line

### DIFF
--- a/htsinfer/get_read_layout.py
+++ b/htsinfer/get_read_layout.py
@@ -20,7 +20,8 @@ LOGGER = logging.getLogger(__name__)
 
 
 class GetReadLayout:
-    """Determine the adapter sequence present in the FASTQ sequencing libraries.
+    """Determine the adapter sequence present in the FASTQ sequencing
+    libraries.
 
     Args:
         config: Container class for all arguments used in inference


### PR DESCRIPTION
### Description
This is a separate PR for the issue that flake8 found a line too long in `get_read_layout.py`.

### Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

### Checklist

Please carefully read these items and tick them off if the statements are true
_or do not apply_.

- [X] I have performed a self-review of my own code
- [X] My code follows the existing coding style, lints and generates no new
      warnings
- [X] I have added type annotations to all function/method signatures, and I
      have added type annotations for any local variables that are non-trivial,
      potentially ambiguous or might otherwise benefit from explicit typing.
- [X] I have commented my code in hard-to-understand areas
- [X] I have added ["Google-style docstrings"] to all new modules, classes,
      methods/functions or updated previously existing ones
- [X] I have added tests that prove my fix is effective or that my feature
      works
- [X] New and existing unit tests pass locally with my changes and I have not
      reduced the code coverage relative to the previous state
- [X] I have updated any sections of the app's documentation that are affected
      by the proposed changes

If for some reason you are unable to tick off all boxes, please leave a
comment explaining the issue you are facing so that we can work on it
together.
