### PR TITLE
ci: downgrade Cutadapt & silence warning

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -13,6 +13,6 @@ dependencies:
   - pysam>=0.16.0
   - python>=3.6, <=3.10
   - star>=2.7.6
-  - cutadapt>=3.5
+  - cutadapt>=3.5, <=4.2
   - pip:
     - -e .

--- a/htsinfer/get_library_source.py
+++ b/htsinfer/get_library_source.py
@@ -268,7 +268,7 @@ class GetLibSource:
             'transcript_id',
             'short_name',
             'taxon_id'
-        ]] = dat.target_id.str.split('|', 4, expand=True)
+        ]] = dat.target_id.str.split('|', n=4, expand=True)
         dat['source_ids'] = list(zip(dat.short_name, dat.taxon_id))
         total_tpm = dat.tpm.sum()
         dat_agg = dat.groupby(['source_ids'])[['tpm']].agg('sum')


### PR DESCRIPTION
- Cap Cutadapt version to `<=4.2` to avoid excessive runtime (https://github.com/marcelm/cutadapt/issues/694)
- Use keyword argument `n` in `pandas.Series.str.split()` to avoid depreciation warning

Fixes #118 
Fixes #120