### PR TITLE
fix: add default to path_2_processed arg

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,7 +142,7 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       github.event_name == 'push' && 
-      github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+      github.ref == 'refs/heads/ci-test'
 
     steps:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,7 +142,7 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       github.event_name == 'push' && 
-      github.ref == 'refs/heads/fix_ci'
+      github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
 
     steps:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,7 +142,7 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       github.event_name == 'push' && 
-      github.ref == 'refs/heads/ci-test'
+      github.ref == 'refs/heads/fix_ci'
 
     steps:
 

--- a/htsinfer/models.py
+++ b/htsinfer/models.py
@@ -456,5 +456,5 @@ class Config(BaseModel):
         results: Container class for aggregating results
                 from the different inference functionalities.
     """
-    args: Args = Args()
+    args: Args = Args(path_2_processed=None)
     results: Results = Results()

--- a/htsinfer/models.py
+++ b/htsinfer/models.py
@@ -440,7 +440,7 @@ class Args(BaseModel):
     read_orientation_min_mapped_reads: int = 20
     read_orientation_min_fraction: float = 0.75
     path_1_processed: Path = Path()
-    path_2_processed: Optional[Path]
+    path_2_processed: Optional[Path] = None
     t_file_processed: Path = Path()
 
 
@@ -456,5 +456,5 @@ class Config(BaseModel):
         results: Container class for aggregating results
                 from the different inference functionalities.
     """
-    args: Args = Args(path_2_processed=None)
+    args: Args = Args()
     results: Results = Results()


### PR DESCRIPTION
### Description

Add  `None` to `path_2_processed: Optional[Path]` as default, to prevent the validation error by Pydantic when initializing the Args class. This caused an issue during the `publish` docker image step of the CI.

### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

### Checklist

Please carefully read these items and tick them off if the statements are true
_or do not apply_.

- [X] I have performed a self-review of my own code
- [X] My code follows the existing coding style, lints and generates no new
      warnings
- [X] I have added type annotations to all function/method signatures, and I
      have added type annotations for any local variables that are non-trivial,
      potentially ambiguous or might otherwise benefit from explicit typing.
- [X] I have commented my code in hard-to-understand areas
- [X] I have added ["Google-style docstrings"] to all new modules, classes,
      methods/functions or updated previously existing ones
- [X] I have added tests that prove my fix is effective or that my feature
      works
- [X] New and existing unit tests pass locally with my changes and I have not
      reduced the code coverage relative to the previous state
- [X] I have updated any sections of the app's documentation that are affected
      by the proposed changes

If for some reason you are unable to tick off all boxes, please leave a
comment explaining the issue you are facing so that we can work on it
together.
