### PR TITLE
fix: update Pydantic version

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,4 +13,4 @@ formats:
    - pdf
    - epub
 conda:
-  environment: environment.yml
+  environment: environment-dev.yml

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -18,7 +18,8 @@ dependencies:
   - pysam >=0.16.0
   - pytest >=6.1.0
   - python >=3.8, <=3.10
+  - python-semantic-release >=8
+  - sphinx-rtd-theme
   - star >=2.7.6
   - pip:
-    - python-semantic-release>=7.15.0
     - -e .

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -13,7 +13,7 @@ dependencies:
   - pandas >=1.3.5, <1.4.0
   - pip >=20.2.3
   - pyahocorasick >=1.4.0
-  - pydantic >=1.8.1, <2
+  - pydantic >=2, <3
   - pylint >=2.4.4
   - pysam >=0.16.0
   - pytest >=6.1.0

--- a/environment.yml
+++ b/environment.yml
@@ -10,7 +10,7 @@ dependencies:
   - pandas >=1.3.5, <1.4.0
   - pip >=20.2.3
   - pyahocorasick >=1.4.0
-  - pydantic >=1.8.1, <2
+  - pydantic >=2, <3
   - pysam >=0.16.0
   - python >=3.8, <=3.10
   - star >=2.7.6

--- a/htsinfer/htsinfer.py
+++ b/htsinfer/htsinfer.py
@@ -315,8 +315,7 @@ class HtsInfer:
     def print(self):
         """Print results to STDOUT."""
         sys.stdout.write(
-            self.config.results.json(
+            self.config.results.model_dump_json(
                 indent=3,
-                sort_keys=False,
             ) + linesep
         )

--- a/tests/test_htsinfer.py
+++ b/tests/test_htsinfer.py
@@ -305,7 +305,7 @@ class TestHtsInfer:
     def test_clean_up_keep_results(self, tmpdir):
         """Remove temporary data."""
         arguments = Args(path_1=FILE_MATE_1,
-                         out_dir=tmpdir,
+                         out_dir=tmpdir.strpath,
                          tmpdir=tmpdir,
                          )
         results = Results()
@@ -323,8 +323,8 @@ class TestHtsInfer:
     def test_clean_up_keep_all(self, tmpdir):
         """Remove no data."""
         arguments = Args(path_1=FILE_MATE_1,
-                         out_dir=tmpdir,
-                         tmpdir=tmpdir,
+                         out_dir=tmpdir.strpath,
+                         tmpdir=tmpdir.strpath,
                          )
         results = Results()
         configs = Config(


### PR DESCRIPTION
### Description

- Update range of supported Pydantic versions (>=2, <3)
- Replace `json` method with `model_dump_json`, remove `dumps_kwargs` argument
- Convert tmpdir path to str before passing as arg by adding `.strpath` attribute to tmpdir in `test_htsinfer.py`, as pydantic was not recognizing at as a valid path

### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

### Checklist

Please carefully read these items and tick them off if the statements are true
_or do not apply_.

- [X] I have performed a self-review of my own code
- [X] My code follows the existing coding style, lints and generates no new
      warnings
- [X] I have added type annotations to all function/method signatures, and I
      have added type annotations for any local variables that are non-trivial,
      potentially ambiguous or might otherwise benefit from explicit typing.
- [X] I have commented my code in hard-to-understand areas
- [X] I have added ["Google-style docstrings"] to all new modules, classes,
      methods/functions or updated previously existing ones
- [X] I have added tests that prove my fix is effective or that my feature
      works
- [X] New and existing unit tests pass locally with my changes and I have not
      reduced the code coverage relative to the previous state
- [X] I have updated any sections of the app's documentation that are affected
      by the proposed changes

If for some reason you are unable to tick off all boxes, please leave a
comment explaining the issue you are facing so that we can work on it
together.
