### PR TITLE
feat: set default for records

### DIFF
--- a/htsinfer/cli.py
+++ b/htsinfer/cli.py
@@ -115,7 +115,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--records",
         dest="records",
-        default=0,
+        default=1000000,
         type=int,
         metavar="INT",
         help=(

--- a/htsinfer/models.py
+++ b/htsinfer/models.py
@@ -427,7 +427,7 @@ class Args(BaseModel):
         Path(tempfile.gettempdir()) / 'tmp_htsinfer'
     cleanup_regime: CleanupRegimes = \
         CleanupRegimes.DEFAULT
-    records: int = 0
+    records: int = 1000000
     threads: int = 1
     transcripts_file: Path = Path()
     read_layout_adapter_file: Path = Path()


### PR DESCRIPTION
### Description

Based on the results from running HTSinfer with various `--records` settings (https://github.com/zavolanlab/htsinfer/issues/109#issuecomment-1801481936), and the discussion that followed, the optimal number for this parameter was found to be 1000000. Records set to 1 million resulted in the lowest number of mismatches for organisms, with an average runtime for the whole process of 540.1 seconds (~9 minutes).  

- Set default parameter for `--records` to 1000000

Closes #109 

### Type of change

- [X] New feature (non-breaking change which adds functionality)

### Checklist

Please carefully read these items and tick them off if the statements are true
_or do not apply_.

- [X] I have performed a self-review of my own code
- [X] My code follows the existing coding style, lints and generates no new
      warnings
- [X] I have added type annotations to all function/method signatures, and I
      have added type annotations for any local variables that are non-trivial,
      potentially ambiguous or might otherwise benefit from explicit typing.
- [X] I have commented my code in hard-to-understand areas
- [X] I have added ["Google-style docstrings"] to all new modules, classes,
      methods/functions or updated previously existing ones
- [X] I have added tests that prove my fix is effective or that my feature
      works
- [X] New and existing unit tests pass locally with my changes and I have not
      reduced the code coverage relative to the previous state
- [X] I have updated any sections of the app's documentation that are affected
      by the proposed changes

If for some reason you are unable to tick off all boxes, please leave a
comment explaining the issue you are facing so that we can work on it
together.
