### PR TITLE
fix: add processed sample paths to mapping

### DIFF
--- a/htsinfer/get_library_type.py
+++ b/htsinfer/get_library_type.py
@@ -131,6 +131,7 @@ plit_mates: 'split_mates'>)
             self.mapping.library_type.relationship \
                 = StatesTypeRelationship.not_available
             self.mapping.library_source = self.library_source
+            self.mapping.paths = (self.path_1, self.path_2)
             self.mapping.evaluate()
             self._align_mates()
 

--- a/htsinfer/get_library_type.py
+++ b/htsinfer/get_library_type.py
@@ -131,7 +131,7 @@ plit_mates: 'split_mates'>)
             self.mapping.library_type.relationship \
                 = StatesTypeRelationship.not_available
             self.mapping.library_source = self.library_source
-            self.mapping.paths = (self.path_1, self.path_2)
+            self.mapping.paths = self.path_1, self.path_2
             self.mapping.evaluate()
             self._align_mates()
 


### PR DESCRIPTION
### Description

Add the paths to the processed subset of samples to the mapping function in `get_library_type.py`, so that STAR makes use of them instead of the original (unprocessed) samples, when aligning to determinate the mate relationship. 

Fixes #149 

### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

### Checklist

Please carefully read these items and tick them off if the statements are true
_or do not apply_.

- [X] I have performed a self-review of my own code
- [X] My code follows the existing coding style, lints and generates no new
      warnings
- [X] I have added type annotations to all function/method signatures, and I
      have added type annotations for any local variables that are non-trivial,
      potentially ambiguous or might otherwise benefit from explicit typing.
- [X] I have commented my code in hard-to-understand areas
- [X] I have added ["Google-style docstrings"] to all new modules, classes,
      methods/functions or updated previously existing ones
- [X] I have added tests that prove my fix is effective or that my feature
      works
- [X] New and existing unit tests pass locally with my changes and I have not
      reduced the code coverage relative to the previous state
- [X] I have updated any sections of the app's documentation that are affected
      by the proposed changes

If for some reason you are unable to tick off all boxes, please leave a
comment explaining the issue you are facing so that we can work on it
together.
