### PR TITLE
fix: correctly infer read stats from second mate

### DIFF
--- a/htsinfer/get_library_stats.py
+++ b/htsinfer/get_library_stats.py
@@ -60,14 +60,14 @@ class GetLibStats:
             self.fastq_get_stats_read_length(fastq=self.paths[0])
         )
         # process file 2
-        LOGGER.info(f"Obtaining statistics for file: {self.paths[0]}")
+        LOGGER.info(f"Obtaining statistics for file: {self.paths[1]}")
         if self.paths[1] is not None:
             (stats.file_2.read_length.min,
              stats.file_2.read_length.max,
              stats.file_2.read_length.mean,
              stats.file_2.read_length.median,
              stats.file_2.read_length.mode) = (
-                self.fastq_get_stats_read_length(fastq=self.paths[0])
+                self.fastq_get_stats_read_length(fastq=self.paths[1])
             )
 
         return stats

--- a/htsinfer/models.py
+++ b/htsinfer/models.py
@@ -95,7 +95,7 @@ class ReadLength(BaseModel):
     min: Optional[int] = None
     max: Optional[int] = None
     mean: Optional[float] = None
-    median: Optional[float] = None
+    median: Optional[int] = None
     mode: Optional[int] = None
 
 


### PR DESCRIPTION
### Description

- Update `get_library_stats.py` so that the read statistics from the second mate would correctly get inferred
- Report median as `int` instead of `float` (this fixes the issue with the [zarp-cli integration htsinfer pipeline](https://github.com/zavolanlab/zarp/actions/runs/7031503464/job/19133341598), as the results json md5sums wouldn't match unless the median was `int`)

Fixes #151 

### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

### Checklist

Please carefully read these items and tick them off if the statements are true
_or do not apply_.

- [X] I have performed a self-review of my own code
- [X] My code follows the existing coding style, lints and generates no new
      warnings
- [X] I have added type annotations to all function/method signatures, and I
      have added type annotations for any local variables that are non-trivial,
      potentially ambiguous or might otherwise benefit from explicit typing.
- [X] I have commented my code in hard-to-understand areas
- [X] I have added ["Google-style docstrings"] to all new modules, classes,
      methods/functions or updated previously existing ones
- [X] I have added tests that prove my fix is effective or that my feature
      works
- [X] New and existing unit tests pass locally with my changes and I have not
      reduced the code coverage relative to the previous state
- [X] I have updated any sections of the app's documentation that are affected
      by the proposed changes

If for some reason you are unable to tick off all boxes, please leave a
comment explaining the issue you are facing so that we can work on it
together.
