### PR TITLE
fix: infer library type relationship

### DIFF
--- a/htsinfer/get_library_type.py
+++ b/htsinfer/get_library_type.py
@@ -127,13 +127,19 @@ plit_mates: 'split_mates'>)
                 self.mapping.library_type.relationship = (
                     StatesTypeRelationship.split_mates
                 )
-        else:
+        elif self.library_source.file_1.short_name is not None \
+                and self.library_source.file_2.short_name is not None:
             self.mapping.library_type.relationship \
                 = StatesTypeRelationship.not_available
             self.mapping.library_source = self.library_source
             self.mapping.paths = self.path_1, self.path_2
             self.mapping.evaluate()
             self._align_mates()
+        else:
+            LOGGER.warning(
+                "Library source is not determined, "
+                "mate relationship cannot be inferred by alignment."
+            )
 
     def _align_mates(self):
         """Decide mate relationship by alignment."""

--- a/htsinfer/get_library_type.py
+++ b/htsinfer/get_library_type.py
@@ -127,8 +127,8 @@ plit_mates: 'split_mates'>)
                 self.mapping.library_type.relationship = (
                     StatesTypeRelationship.split_mates
                 )
-        elif self.library_source.file_1.short_name is not None \
-                and self.library_source.file_2.short_name is not None:
+        elif (self.library_source.file_1.short_name is not None
+              and self.library_source.file_2.short_name is not None):
             self.mapping.library_type.relationship \
                 = StatesTypeRelationship.not_available
             self.mapping.library_source = self.library_source

--- a/htsinfer/get_library_type.py
+++ b/htsinfer/get_library_type.py
@@ -113,7 +113,7 @@ plit_mates: 'split_mates'>)
             ids_2: As `ids_1` but for the putative second mate file.
         """
         self.results.relationship = StatesTypeRelationship.not_mates
-        if ids_1 == ids_2 and len(ids_1) > 0 and len(ids_2) > 0:
+        if ids_1 and ids_2 and ids_1 == ids_2:
             if (
                 self.results.file_1 == StatesType.first_mate and
                 self.results.file_2 == StatesType.second_mate
@@ -140,8 +140,7 @@ plit_mates: 'split_mates'>)
         else:
             self.results.relationship = StatesTypeRelationship.not_available
             LOGGER.debug(
-                "Library source is not determined, "
-                "mate relationship cannot be inferred by alignment."
+                "Mate relationship cannot be determined."
             )
 
     def _align_mates(self):
@@ -165,6 +164,7 @@ plit_mates: 'split_mates'>)
         concordant = 0
 
         for read1 in samfile1:
+            # ensure that "unmapped" flag is not set and query name is set
             if not read1.flag & (1 << 2) and isinstance(read1.query_name, str):
                 seq_id1 = read1.query_name
                 if (
@@ -180,6 +180,7 @@ plit_mates: 'split_mates'>)
 
         read_counter = 0
         for read2 in samfile2:
+            # ensure that "unmapped" flag is not set and query name is set
             if not read2.flag & (1 << 2) and isinstance(read2.query_name, str):
                 seq_id2 = read2.query_name
                 if seq_id2 != previous_seq_id2 \
@@ -219,8 +220,9 @@ plit_mates: 'split_mates'>)
                 self.results.relationship = (
                     StatesTypeRelationship.split_mates
                 )
-                self.mapping.library_type.relationship \
-                    = StatesTypeRelationship.split_mates
+                self.mapping.library_type.relationship = (
+                    StatesTypeRelationship.split_mates
+                )
                 self.mapping.mapped = False
                 self.mapping.star_dirs = []
             else:

--- a/htsinfer/get_library_type.py
+++ b/htsinfer/get_library_type.py
@@ -128,9 +128,10 @@ plit_mates: 'split_mates'>)
                     StatesTypeRelationship.split_mates
                 )
         elif (
-            self.library_source.file_1.short_name is not None and
+            self.library_source.file_1.short_name is not None or
             self.library_source.file_2.short_name is not None
         ):
+            LOGGER.debug("Determining mate relationship by alignment...")
             self.mapping.library_type.relationship \
                 = StatesTypeRelationship.not_available
             self.mapping.library_source = self.library_source
@@ -140,7 +141,8 @@ plit_mates: 'split_mates'>)
         else:
             self.results.relationship = StatesTypeRelationship.not_available
             LOGGER.debug(
-                "Mate relationship cannot be determined."
+                "Sequence IDs and library source are not determined, "
+                "mate relationship cannot be inferred."
             )
 
     def _align_mates(self):

--- a/htsinfer/get_library_type.py
+++ b/htsinfer/get_library_type.py
@@ -135,6 +135,7 @@ plit_mates: 'split_mates'>)
             self.mapping.evaluate()
             self._align_mates()
 
+    # pylint: disable=R0912
     def _align_mates(self):
         """Decide mate relationship by alignment."""
 
@@ -186,7 +187,7 @@ plit_mates: 'split_mates'>)
         if self._compare_alignments(mate1[read_counter], reads2):
             concordant += 1
 
-        if read_counter > 0:
+        try:
             if (concordant / read_counter) >= self.cutoff:
                 self.results.relationship = (
                     StatesTypeRelationship.split_mates
@@ -199,7 +200,7 @@ plit_mates: 'split_mates'>)
                 self.results.relationship = (
                     StatesTypeRelationship.not_mates
                 )
-        else:
+        except ZeroDivisionError:
             self.results.relationship = (
                 StatesTypeRelationship.not_available
             )

--- a/htsinfer/get_library_type.py
+++ b/htsinfer/get_library_type.py
@@ -206,7 +206,13 @@ plit_mates: 'split_mates'>)
     def _update_relationship(self, concordant, read_counter):
         """Helper function to update relationship based on alignment."""
         try:
-            if (concordant / read_counter) >= self.cutoff:
+            ratio = concordant / read_counter
+        except ZeroDivisionError:
+            self.results.relationship = (
+                StatesTypeRelationship.not_available
+            )
+        else:
+            if ratio >= self.cutoff:
                 self.results.relationship = (
                     StatesTypeRelationship.split_mates
                 )
@@ -218,10 +224,6 @@ plit_mates: 'split_mates'>)
                 self.results.relationship = (
                     StatesTypeRelationship.not_mates
                 )
-        except ZeroDivisionError:
-            self.results.relationship = (
-                StatesTypeRelationship.not_available
-            )
 
     class AlignedSegment:
         """Placeholder class for mypy "Missing attribute"
@@ -331,7 +333,7 @@ class GetFastqType():
 
                 if self.seq_id_format is None:
                     self.result = StatesType.not_available
-                    LOGGER.warning(
+                    LOGGER.debug(
                         "Could not determine sequence identifier format."
                     )
                 else:

--- a/htsinfer/get_library_type.py
+++ b/htsinfer/get_library_type.py
@@ -135,7 +135,6 @@ plit_mates: 'split_mates'>)
             self.mapping.evaluate()
             self._align_mates()
 
-    # pylint: disable=R0912
     def _align_mates(self):
         """Decide mate relationship by alignment."""
 
@@ -187,6 +186,13 @@ plit_mates: 'split_mates'>)
         if self._compare_alignments(mate1[read_counter], reads2):
             concordant += 1
 
+        self._update_relationship(concordant, read_counter)
+
+        samfile1.close()
+        samfile2.close()
+
+    def _update_relationship(self, concordant, read_counter):
+        """Helper function to update relationship based on alignment."""
         try:
             if (concordant / read_counter) >= self.cutoff:
                 self.results.relationship = (
@@ -204,9 +210,6 @@ plit_mates: 'split_mates'>)
             self.results.relationship = (
                 StatesTypeRelationship.not_available
             )
-
-        samfile1.close()
-        samfile2.close()
 
     class AlignedSegment:
         """Placeholder class for mypy "Missing attribute"

--- a/htsinfer/get_library_type.py
+++ b/htsinfer/get_library_type.py
@@ -127,8 +127,10 @@ plit_mates: 'split_mates'>)
                 self.mapping.library_type.relationship = (
                     StatesTypeRelationship.split_mates
                 )
-        elif (self.library_source.file_1.short_name is not None
-              and self.library_source.file_2.short_name is not None):
+        elif (
+            self.library_source.file_1.short_name is not None and
+            self.library_source.file_2.short_name is not None
+        ):
             self.mapping.library_type.relationship \
                 = StatesTypeRelationship.not_available
             self.mapping.library_source = self.library_source
@@ -136,6 +138,7 @@ plit_mates: 'split_mates'>)
             self.mapping.evaluate()
             self._align_mates()
         else:
+            self.results.relationship = StatesTypeRelationship.not_available
             LOGGER.debug(
                 "Library source is not determined, "
                 "mate relationship cannot be inferred by alignment."
@@ -195,8 +198,8 @@ plit_mates: 'split_mates'>)
             mate1[read_counter], reads2
         ):
             concordant += 1
-        LOGGER.debug(f"Number of mapped reads file 1: {len(mate1)}")
-        LOGGER.debug(f"Number of mapped reads file 2: {read_counter}")
+        LOGGER.debug(f"Number of aligned reads file 1: {len(mate1)}")
+        LOGGER.debug(f"Number of aligned reads file 2: {read_counter}")
         LOGGER.debug(f"Number of concordant reads: {concordant}")
         self._update_relationship(concordant, read_counter)
 
@@ -331,25 +334,26 @@ class GetFastqType():
                     self.result = StatesType.not_available
                     raise FileProblem(f"File is empty: {self.path}") from exc
 
-                if self.seq_id_format is None:
-                    self.result = StatesType.not_available
-                    LOGGER.debug(
-                        "Could not determine sequence identifier format."
-                    )
-                else:
+                if self.seq_id_format is not None:
                     LOGGER.debug(
                         "Sequence identifier format: "
                         f"{self.seq_id_format.name}"
+                    )
+                else:
+                    self.result = StatesType.not_available
+                    LOGGER.debug(
+                        "Could not determine sequence identifier format."
                     )
 
                 # Ensure that remaining records are compatible with sequence
                 # identifier format and library type determined from first
                 # record
-                LOGGER.debug(
-                    "Checking consistency of remaining reads with initially "
-                    "determined identifier format and library type..."
-                )
                 if self.seq_id_format is not None:
+                    LOGGER.debug(
+                        "Checking consistency of remaining reads with "
+                        "initially determined identifier format "
+                        "and library type..."
+                    )
                     for record in seq_iter:
                         records += 1
                         try:
@@ -366,11 +370,6 @@ class GetFastqType():
                                 f"{type(exc).__name__}: {str(exc)}"
                             ) from exc
                     LOGGER.debug(f"Total records processed: {records}")
-                else:
-                    LOGGER.debug(
-                        "Could not determine sequence identifier format. "
-                        "Skipping consistency check for the remaining reads."
-                    )
 
         except (OSError, ValueError) as exc:
             self.result = StatesType.not_available

--- a/htsinfer/get_read_orientation.py
+++ b/htsinfer/get_read_orientation.py
@@ -75,9 +75,10 @@ class GetOrientation:
         self.mapping.transcripts_file = self.transcripts_file
         self.mapping.tmp_dir = self.tmp_dir
 
-        if not self.mapping.mapped \
-                and (self.library_source.file_1.short_name is not None
-                     or self.library_source.file_2.short_name is not None):
+        if not self.mapping.mapped and (
+            self.library_source.file_1.short_name is not None or
+            self.library_source.file_2.short_name is not None
+        ):
             self.mapping.evaluate()
         else:
             LOGGER.debug(

--- a/htsinfer/get_read_orientation.py
+++ b/htsinfer/get_read_orientation.py
@@ -79,11 +79,8 @@ class GetOrientation:
             self.library_source.file_1.short_name is not None or
             self.library_source.file_2.short_name is not None
         ):
+            LOGGER.debug("Determining read relationship by alignment...")
             self.mapping.evaluate()
-        else:
-            LOGGER.debug(
-                "Read orientation cannot be determined."
-            )
 
         return self.process_alignments(star_dirs=self.mapping.star_dirs)
 

--- a/htsinfer/get_read_orientation.py
+++ b/htsinfer/get_read_orientation.py
@@ -80,7 +80,7 @@ class GetOrientation:
                      or self.library_source.file_2.short_name is not None):
             self.mapping.evaluate()
         else:
-            LOGGER.warning(
+            LOGGER.debug(
                 "Library source is not determined, "
                 "read orientation cannot be inferred by alignment."
             )

--- a/htsinfer/get_read_orientation.py
+++ b/htsinfer/get_read_orientation.py
@@ -75,8 +75,15 @@ class GetOrientation:
         self.mapping.transcripts_file = self.transcripts_file
         self.mapping.tmp_dir = self.tmp_dir
 
-        if not self.mapping.mapped:
+        if not self.mapping.mapped \
+                and self.library_source.file_1.short_name is not None \
+                and self.library_source.file_2.short_name is not None:
             self.mapping.evaluate()
+        else:
+            LOGGER.warning(
+                "Library source is not determined, "
+                "read orientation cannot be inferred by alignment."
+            )
 
         return self.process_alignments(star_dirs=self.mapping.star_dirs)
 

--- a/htsinfer/get_read_orientation.py
+++ b/htsinfer/get_read_orientation.py
@@ -82,8 +82,7 @@ class GetOrientation:
             self.mapping.evaluate()
         else:
             LOGGER.debug(
-                "Library source is not determined, "
-                "read orientation cannot be inferred by alignment."
+                "Read orientation cannot be determined."
             )
 
         return self.process_alignments(star_dirs=self.mapping.star_dirs)

--- a/htsinfer/get_read_orientation.py
+++ b/htsinfer/get_read_orientation.py
@@ -77,7 +77,7 @@ class GetOrientation:
 
         if not self.mapping.mapped \
                 and self.library_source.file_1.short_name is not None \
-                and self.library_source.file_2.short_name is not None:
+                or self.library_source.file_2.short_name is not None:
             self.mapping.evaluate()
         else:
             LOGGER.warning(

--- a/htsinfer/get_read_orientation.py
+++ b/htsinfer/get_read_orientation.py
@@ -76,8 +76,8 @@ class GetOrientation:
         self.mapping.tmp_dir = self.tmp_dir
 
         if not self.mapping.mapped \
-                and self.library_source.file_1.short_name is not None \
-                or self.library_source.file_2.short_name is not None:
+                and (self.library_source.file_1.short_name is not None
+                     or self.library_source.file_2.short_name is not None):
             self.mapping.evaluate()
         else:
             LOGGER.warning(

--- a/htsinfer/mapping.py
+++ b/htsinfer/mapping.py
@@ -299,6 +299,7 @@ class Mapping:
                 "--runThreadN", f"{str(self.threads_star)}",
                 "--genomeDir", f"{str(index_dir)}",
                 "--outFilterMultimapNmax", "50",
+                "--outSAMorder", "PairedKeepInputOrder",
                 "--outSAMunmapped", "Within", "KeepPairs",
             ]
             cmd: List[str] = cmd_base[:]

--- a/htsinfer/mapping.py
+++ b/htsinfer/mapping.py
@@ -51,11 +51,7 @@ class Mapping:
         self.star_dirs: List[Path] = []
 
     def evaluate(self):
-        """Infer read orientation.
-
-        Returns:
-            Orientation results object.
-        """
+        """Align FASTQ files to reference transcripts with STAR."""
 
         # get transcripts for current organims
         transcripts = self.subset_transcripts_by_organism()
@@ -269,6 +265,10 @@ class Mapping:
             index_dir: Path,
     ) -> Dict[Path, List[str]]:
         """Prepare STAR alignment commands.
+
+        Input FASTQ files are assumed to be sorted according to reference names
+        or coordinates, the order of input reads is kept with the option
+        "PairedKeepInputOrder", no additional sorting of aligned reads is done.
 
         Args:
             index_dir: Path to directory containing STAR index.

--- a/tests/test_get_library_type.py
+++ b/tests/test_get_library_type.py
@@ -113,6 +113,35 @@ class TestGetLibType:
 
     def test_evaluate_mate_relationship_not_mates(self, tmpdir):
         """Test mate relationship evaluation logic with input files that are
+        mates, but the relationship is not enough to trigger split_mates.
+        """
+        CONFIG.args.path_1_processed = FILE_MATE_1
+        CONFIG.args.path_2_processed = FILE_MATE_2
+        CONFIG.args.t_file_processed = FILE_TRANSCRIPTS
+        CONFIG.args.tmp_dir = tmpdir
+        MAPPING.paths = (FILE_MATE_1, FILE_MATE_2)
+        MAPPING.transcripts_file = FILE_TRANSCRIPTS
+        MAPPING.tmp_dir = tmpdir
+
+        test_instance = GetLibType(config=CONFIG, mapping=MAPPING)
+        test_instance.results.file_1 = StatesType.not_available
+        test_instance.results.file_2 = StatesType.not_available
+
+        # Set the cutoff such that it's not enough to trigger split_mates
+        test_instance.cutoff = 300
+
+        # Call the _evaluate_mate_relationship method
+        test_instance._evaluate_mate_relationship(
+            ids_1=["A", "B", "C"], ids_2=["A", "B", "C"]
+        )
+
+        assert (
+            test_instance.results.relationship ==
+            StatesTypeRelationship.not_mates
+        )
+
+    def test_evaluate_mate_relationship_not_available(self, tmpdir):
+        """Test mate relationship evaluation logic with input files that are
         not mates from a paired-end library.
         """
         CONFIG.args.path_1_processed = FILE_IDS_NOT_MATCH_1
@@ -124,12 +153,12 @@ class TestGetLibType:
         MAPPING.tmp_dir = tmpdir
         test_instance = GetLibType(config=CONFIG,
                                    mapping=MAPPING)
-        test_instance.results.file_1 = StatesType.first_mate
-        test_instance.results.file_2 = StatesType.second_mate
+        test_instance.results.file_1 = StatesType.not_available
+        test_instance.results.file_2 = StatesType.not_available
         test_instance.evaluate()
         assert (
             test_instance.results.relationship ==
-            StatesTypeRelationship.not_mates
+            StatesTypeRelationship.not_available
         )
 
     def test_evaluate_split_mates_not_matching_ids(self, tmpdir):

--- a/tests/test_get_library_type.py
+++ b/tests/test_get_library_type.py
@@ -33,7 +33,6 @@ from tests.utils import (
     FILE_IDS_NOT_MATCH_2,
     FILE_TRANSCRIPTS,
     FILE_SINGLE,
-    FILE_UNKNOWN_SEQ_ID,
     RaiseError,
     SEQ_ID_DUMMY,
     SEQ_ID_MATE_1,

--- a/tests/test_get_library_type.py
+++ b/tests/test_get_library_type.py
@@ -13,7 +13,9 @@ from htsinfer.get_library_type import (
     GetFastqType,
 )
 from htsinfer.models import (
+    ResultsSource,
     ResultsType,
+    Source,
     SeqIdFormats,
     StatesType,
     StatesTypeRelationship,
@@ -147,6 +149,10 @@ class TestGetLibType:
         CONFIG.args.path_1_processed = FILE_IDS_NOT_MATCH_1
         CONFIG.args.path_2_processed = FILE_MATE_2
         CONFIG.args.t_file_processed = FILE_TRANSCRIPTS
+        CONFIG.results.library_source = ResultsSource(
+            file_1=Source(short_name="hsapiens", taxon_id=9606),
+            file_2=Source(short_name="hsapiens", taxon_id=9606),
+        )
         CONFIG.args.tmp_dir = tmpdir
         MAPPING.paths = (FILE_IDS_NOT_MATCH_1, FILE_MATE_2)
         MAPPING.transcripts_file = FILE_TRANSCRIPTS
@@ -167,6 +173,10 @@ class TestGetLibType:
         """
         CONFIG.args.path_1_processed = FILE_IDS_NOT_MATCH_1
         CONFIG.args.path_2_processed = FILE_IDS_NOT_MATCH_2
+        CONFIG.results.library_source = ResultsSource(
+            file_1=Source(short_name="hsapiens", taxon_id=9606),
+            file_2=Source(short_name="hsapiens", taxon_id=9606),
+        )
         CONFIG.args.tmp_dir = tmpdir
         MAPPING.paths = (FILE_IDS_NOT_MATCH_1, FILE_IDS_NOT_MATCH_2)
         MAPPING.tmp_dir = tmpdir

--- a/tests/test_get_library_type.py
+++ b/tests/test_get_library_type.py
@@ -214,12 +214,6 @@ class TestGetFastqType:
         test_instance.evaluate()
         assert test_instance.result == StatesType.single
 
-    def test_evaluate_unknown_seq_id(self):
-        """Evaluate file with identifiers of an unknown format."""
-        test_instance = GetFastqType(path=FILE_UNKNOWN_SEQ_ID)
-        with pytest.raises(MetadataWarning):
-            test_instance.evaluate()
-
     def test_evaluate_inconsistent_identifiers_single_mate(self):
         """Raise ``MetadataWarning`` by passing a file with inconsistent
         identifiers, suggesting a single-end library first, then a paired-end

--- a/tests/test_get_read_orientation.py
+++ b/tests/test_get_read_orientation.py
@@ -73,6 +73,10 @@ class TestGetOrientation:
         CONFIG.args.path_2_processed = FILE_MATE_2
         CONFIG.args.t_file_processed = FILE_TRANSCRIPTS
         CONFIG.args.tmp_dir = tmpdir
+        CONFIG.results.library_source = ResultsSource(
+            file_1=Source(),
+            file_2=Source()
+        )
         test_instance = GetOrientation(config=CONFIG,
                                        mapping=MAPPING)
         assert test_instance.paths[0] == FILE_MATE_1

--- a/tests/test_get_read_orientation.py
+++ b/tests/test_get_read_orientation.py
@@ -154,7 +154,10 @@ class TestGetOrientation:
         CONFIG.args.path_1_processed = FILE_UNMAPPED_PAIRED_1
         CONFIG.args.path_2_processed = FILE_UNMAPPED_PAIRED_2
         CONFIG.args.tmp_dir = tmpdir
-        CONFIG.results.library_source = ResultsSource()
+        CONFIG.results.library_source = ResultsSource(
+            file_1=Source(short_name="hsapiens", taxon_id=9606),
+            file_2=Source(short_name="hsapiens", taxon_id=9606)
+        )
         CONFIG.results.library_type = ResultsType(
             relationship=StatesTypeRelationship.split_mates,
         )
@@ -259,7 +262,7 @@ class TestGetOrientation:
             )
         CONFIG.results.library_source = ResultsSource(
             file_1=Source(),
-            file_2=Source(),
+            file_2=Source(short_name="hsapiens", taxon_id=9606),
         )
         CONFIG.args.tmp_dir = tmpdir
         MAPPING.mapped = False

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -187,7 +187,8 @@ class TestMapping:
         file1_alignment_path = tmpdir / 'alignments/file_1'
         cmd = "STAR --alignIntronMax 1 --alignEndsType Local --runThreadN 1" \
             + " --genomeDir " + str(index_dir) + " --outFilterMultimapNmax " \
-            + "50 --outSAMunmapped Within KeepPairs --readFilesIn " \
+            + "50 --outSAMorder PairedKeepInputOrder " \
+            + "--outSAMunmapped Within KeepPairs --readFilesIn " \
             + str(FILE_2000_RECORDS) + " --outFileNamePrefix " \
             + str(file1_alignment_path) + "/"
         results = test_instance.prepare_star_alignment_commands(


### PR DESCRIPTION
### Description

- Add check to assign `first_mate` and `second_mate` when it can correctly be inferred from seq_id's (when seq_ids are not empty)
- Add check to only align when `library source` is either inferred or given by `--tax-id` argument (in case of `library type` as well as `read orientation` inference)
- Add `--outSAMorder PairedKeepInputOrder` to `mapping.py` to keep input order of reads when running STAR with multiple threads
- Update tests

In the case of paired-end libraries, the logic should be:

1. For the library type inference, check `seq_ids` of first and second pair, to decide if they fit the Casava format, and the lib type and relationship can be determined
2. If not, as in most SRA samples, align them separately to reference transcripts, but only if `library_source` is known
3. Compare alignments and decide relationship
4. For the orientation inference, based on the library type relationship determined:
    1. If `not_mates` or `not_available`, infer the orientation from the separately aligned results
    2. If  `split_mates`, align the samples in paired-end mode, but only if `library_source` is known


Fixes #153 

### Type of change

- [X] New feature (non-breaking change which adds functionality)

### Checklist

Please carefully read these items and tick them off if the statements are true
_or do not apply_.

- [X] I have performed a self-review of my own code
- [X] My code follows the existing coding style, lints and generates no new
      warnings
- [X] I have added type annotations to all function/method signatures, and I
      have added type annotations for any local variables that are non-trivial,
      potentially ambiguous or might otherwise benefit from explicit typing.
- [X] I have commented my code in hard-to-understand areas
- [X] I have added ["Google-style docstrings"] to all new modules, classes,
      methods/functions or updated previously existing ones
- [X] I have added tests that prove my fix is effective or that my feature
      works
- [X] New and existing unit tests pass locally with my changes and I have not
      reduced the code coverage relative to the previous state
- [X] I have updated any sections of the app's documentation that are affected
      by the proposed changes

If for some reason you are unable to tick off all boxes, please leave a
comment explaining the issue you are facing so that we can work on it
together.
