### PR TITLE
feat: improve lib type inference for SRA PE samples

### DIFF
--- a/htsinfer/cli.py
+++ b/htsinfer/cli.py
@@ -232,7 +232,7 @@ def parse_args() -> argparse.Namespace:
         dest="lib_type_mates_cutoff",
         metavar="FLOAT",
         type=float,
-        default=0.95,
+        default=0.85,
         help=(
             "minimum fraction of mates that can be mapped to compatible loci "
             "and are considered concordant pairs / all mates"

--- a/htsinfer/models.py
+++ b/htsinfer/models.py
@@ -155,9 +155,11 @@ class StatesType(Enum):
             that the library represents a single-end library.
     """
     first_mate = "first_mate"
+    first_mate_assumed = "first_mate_assumed"
     mixed_mates = "mixed_mates"
     not_available = None
     second_mate = "second_mate"
+    second_mate_assumed = "second_mate_assumed"
     single = "single"
 
 
@@ -438,7 +440,7 @@ class Args(BaseModel):
     lib_source_min_match_pct: float = 2
     lib_source_min_freq_ratio: float = 2
     lib_type_max_distance: int = 1000
-    lib_type_mates_cutoff: float = 0.95
+    lib_type_mates_cutoff: float = 0.85
     read_orientation_min_mapped_reads: int = 20
     read_orientation_min_fraction: float = 0.75
     path_1_processed: Path = Path()

--- a/tests/test_get_library_type.py
+++ b/tests/test_get_library_type.py
@@ -113,6 +113,34 @@ class TestGetLibType:
             StatesTypeRelationship.split_mates
         )
 
+    def test_evaluate_mate_relationship_assumed_single(self, tmpdir):
+        """Test mate relationship evaluation logic with input files being
+        mates of a paired-end library but assumed single based on seq_ids.
+        """
+        CONFIG.args.path_1_processed = FILE_MATE_1
+        CONFIG.args.path_2_processed = FILE_MATE_2
+        CONFIG.args.t_file_processed = FILE_TRANSCRIPTS
+        CONFIG.args.tmp_dir = tmpdir
+        CONFIG.results.library_source = ResultsSource(
+            file_1=Source(short_name="hsapiens", taxon_id=9606),
+            file_2=Source(short_name="hsapiens", taxon_id=9606),
+        )
+        MAPPING.paths = (FILE_MATE_1, FILE_MATE_2)
+        MAPPING.transcripts_file = FILE_TRANSCRIPTS
+        MAPPING.tmp_dir = tmpdir
+        test_instance = GetLibType(config=CONFIG,
+                                   mapping=MAPPING)
+        test_instance.results.file_1 = StatesType.single
+        test_instance.results.file_2 = StatesType.single
+        test_instance._evaluate_mate_relationship(
+            ids_1=["A", "B", "C"],
+            ids_2=["A", "B", "C"],
+        )
+        assert (
+            test_instance.results.relationship ==
+            StatesTypeRelationship.not_available
+        )
+
     def test_evaluate_mate_relationship_not_mates(self, tmpdir):
         """Test mate relationship evaluation logic with input files that are
         mates, but the relationship is not enough to trigger split_mates.
@@ -167,7 +195,7 @@ class TestGetLibType:
             StatesTypeRelationship.not_available
         )
 
-    def test_update_relationship_not_mates(self, tmpdir):
+    def test_update_relationship_type_not_mates(self, tmpdir):
         """Test update_relationship logic."""
         CONFIG.args.path_1_processed = FILE_IDS_NOT_MATCH_1
         CONFIG.args.path_2_processed = FILE_MATE_2
@@ -185,8 +213,8 @@ class TestGetLibType:
         concordant = 0
         read_counter = 20
 
-        # Call the _update_relationship method
-        test_instance._update_relationship(concordant, read_counter)
+        # Call the _update_relationship_type method
+        test_instance._update_relationship_type(concordant, read_counter)
 
         assert (
             test_instance.results.relationship ==


### PR DESCRIPTION
### Description

- Expand `_evaluate_mate_relationship` for library type relationship inference to align samples when two input files are given but both are deemed `single`
- Add additional library type states `first_mate_assumed` and `second_mate_assumed`, when the relationship is determined to be `split_mates`, refactor `_update_relationship_type` helper function to assign states types
- Update tests
- Lower `lib_type_mates_cutoff` to 0.85 based on results from #160 

Closes #160 

### Type of change

- [X] New feature (non-breaking change which adds functionality)

### Checklist

Please carefully read these items and tick them off if the statements are true
_or do not apply_.

- [X] I have performed a self-review of my own code
- [X] My code follows the existing coding style, lints and generates no new
      warnings
- [X] I have added type annotations to all function/method signatures, and I
      have added type annotations for any local variables that are non-trivial,
      potentially ambiguous or might otherwise benefit from explicit typing.
- [X] I have commented my code in hard-to-understand areas
- [X] I have added ["Google-style docstrings"] to all new modules, classes,
      methods/functions or updated previously existing ones
- [X] I have added tests that prove my fix is effective or that my feature
      works
- [X] New and existing unit tests pass locally with my changes and I have not
      reduced the code coverage relative to the previous state
- [X] I have updated any sections of the app's documentation that are affected
      by the proposed changes

If for some reason you are unable to tick off all boxes, please leave a
comment explaining the issue you are facing so that we can work on it
together.
